### PR TITLE
Test: Add test to cover branch in utils/python.py get_func_args

### DIFF
--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -23,6 +23,20 @@ class ItemTest(unittest.TestCase):
         i['name'] = u'name'
         self.assertEqual(i['name'], u'name')
 
+    def test_delete_item(self):
+        #contract: If you remove the item the list should be one size smaller 
+        #and the object no longer accessible
+        class TestItem(Item):
+            pass
+        i = TestItem()
+        i.fields['a'] = 'a'
+        i.__setitem__('a','2')
+        self.assertEqual(1,i.__len__())
+        i.__delitem__('a')
+        self.assertEqual(0,i.__len__())
+        self.assertRaises(KeyError, i.__getitem__, 'a')
+
+
     def test_init(self):
         class TestItem(Item):
             name = Field()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -136,6 +136,15 @@ class BasicItemLoaderTest(unittest.TestCase):
         il.add_value(None, u'Jim', lambda x: {'name': x})
         self.assertEqual(il.get_collected_values('name'), [u'Marta', u'Pepe', u'Jim'])
 
+
+    def test_add_none(self):
+        #If None is added, nothing should change
+        val = None
+        il = NameItemLoader()
+        self.assertEqual('name', il.get_value('name'))
+        il.add_value('name',val)
+        self.assertEqual('name', il.get_value('name'))
+
     def test_add_zero(self):
         il = NameItemLoader()
         il.add_value('name', 0)
@@ -152,6 +161,15 @@ class BasicItemLoaderTest(unittest.TestCase):
 
         il.replace_value(None, u'Jim', lambda x: {'name': x})
         self.assertEqual(il.get_collected_values('name'), [u'Jim'])
+
+    def test_replace_none(self):
+        #If None is replaced, nothing should change
+        val = None
+        il = NameItemLoader()
+        il.add_value('name', u'Marta')
+        self.assertEqual(il.get_collected_values('name'), [u'Marta'])
+        il.replace_value('name',val)
+        self.assertEqual(il.get_collected_values('name'), [u'Marta'])
 
     def test_get_value(self):
         il = NameItemLoader()

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -212,6 +212,11 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertEqual(get_func_args(partial_f3), ['c'])
         self.assertEqual(get_func_args(cal), ['a', 'b', 'c'])
         self.assertEqual(get_func_args(object), [])
+        
+        #If the parameter of the function is not callable it should raise
+        #a TypeError error (5 is not callable)
+        self.assertRaises(TypeError, get_func_args, 5)
+
 
         if platform.python_implementation() == 'CPython':
             # TODO: how do we fix this to return the actual argument names?


### PR DESCRIPTION
The test never went down the branch that raises and error when the
parameter is not callable. This was done by sending a 5 which is not
callable

Issue #18