### PR TITLE
Test: Improve branch coverage in _parse_sitemap 

### DIFF
--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -347,6 +347,19 @@ class SitemapSpiderTest(SpiderTest):
         result = next(spider._parse_sitemap(r),None)
         self.assertIsNone(result)
 
+    def test_sitemap_index_w_locs_no_match(self):
+        #contract/requirement: Sitemapindex with locs where SitemapSpider does not match anything, nothing should be returned 
+        sitemap = b"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap><loc>http://www.example.com/sitemap1.xml.gz</loc><lastmod>2004-10-01T18:23:17+00:00</lastmod>
+                </sitemap>
+                <sitemap><loc>http://www.example.com/sitemap2.xml.gz</loc>
+                <lastmod>2005-01-01</lastmod></sitemap></sitemapindex>"""
+        r = TextResponse(url="http://www.example.com/sitemap.xml", body=sitemap)
+        SitemapSpider.sitemap_follow = []
+        spider = self.spider_class("example.com")
+        self.assertEqual([req.url for req in spider._parse_sitemap(r)],[])
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files
 Sitemap: http://example.com/sitemap.xml

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -338,6 +338,15 @@ class SitemapSpiderTest(SpiderTest):
         url = next(spider._parse_sitemap(r),None)
         self.assertIsNone(url)
 
+    def test_sitemap_index(self):
+        sitemap = b"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>"""
+        r = TextResponse(url="http://www.example.com/sitemap.xml", body=sitemap)
+        spider = self.spider_class("example.com")
+        result = next(spider._parse_sitemap(r),None)
+        self.assertIsNone(result)
+
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files
 Sitemap: http://example.com/sitemap.xml

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -360,6 +360,19 @@ class SitemapSpiderTest(SpiderTest):
         SitemapSpider.sitemap_follow = []
         spider = self.spider_class("example.com")
         self.assertEqual([req.url for req in spider._parse_sitemap(r)],[])
+    def test_sitemap_index_w_locs_match(self):
+        #contract/requirement: Sitemapindex with locs wherw SitemapSpider match everything, all locs found should be returned
+        sitemap = b"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap><loc>http://www.example.com/sitemap1.xml.gz</loc><lastmod>2004-10-01T18:23:17+00:00</lastmod>
+                </sitemap>
+                <sitemap><loc>http://www.example.com/sitemap2.xml.gz</loc>
+                <lastmod>2005-01-01</lastmod></sitemap></sitemapindex>"""
+        r = TextResponse(url="http://www.example.com/sitemap.xml", body=sitemap)
+        spider = self.spider_class("example.com")
+        self.assertEqual([req.url for req in spider._parse_sitemap(r)],["http://www.example.com/sitemap1.xml.gz","http://www.example.com/sitemap2.xml.gz"])
+
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files
 Sitemap: http://example.com/sitemap.xml

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -333,12 +333,14 @@ class SitemapSpiderTest(SpiderTest):
         self.assertSitemapBody(r, self.BODY)
     
     def test_no_robot_no_body(self):
+        #contract/requirment: the parse_sitemap should return None if the request body is None
         spider = self.spider_class("example.com")
         r = Response(url="http://www.example.com/site", body=None)
         url = next(spider._parse_sitemap(r),None)
         self.assertIsNone(url)
 
     def test_sitemap_index(self):
+        #contract/requirment: A sitemapindex with no locs should return None
         sitemap = b"""
                 <?xml version="1.0" encoding="UTF-8"?>
                 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>"""

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -331,6 +331,12 @@ class SitemapSpiderTest(SpiderTest):
         # .xml.gz but body decoded by HttpCompression middleware already
         r = Response(url="http://www.example.com/sitemap.xml.gz", body=self.BODY)
         self.assertSitemapBody(r, self.BODY)
+    
+    def test_no_robot_no_body(self):
+        spider = self.spider_class("example.com")
+        r = Response(url="http://www.example.com/site", body=None)
+        url = next(spider._parse_sitemap(r),None)
+        self.assertIsNone(url)
 
     def test_get_sitemap_urls_from_robotstxt(self):
         robots = b"""# Sitemap files


### PR DESCRIPTION
These are my 4 new tests that increase the branch coverage of the `_parse_sitemap` function of the `scrapy/spiders/sitemap` file .

For this particular function it will increase from 7/11 to 11/11 or and increase of 57% in test coverage (or 45 percentage points).